### PR TITLE
feat/list surveys

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "husky": "^8.0.2",
     "jest": "^29.3.1",
     "lint-staged": "^13.1.0",
+    "mockdate": "^3.0.5",
     "rimraf": "^3.0.2",
     "standard": "^17.0.0",
     "sucrase": "^3.29.0",

--- a/requirements/surveys.md
+++ b/requirements/surveys.md
@@ -1,0 +1,13 @@
+# Listar enquetes
+
+> ## Caso de sucesso
+
+1.⛔ Recebe uma requisição do tipo **GET** na rota **/api/surveys**
+2.⛔ Valida se a requisição foi feita por um usuário
+3.⛔ Retorna 200 com os dados das enquetes
+
+> ## Exceções
+
+1.⛔ Retorna erro 404 se a API não existir
+2.⛔ Retorna error 403 se não for um usuário válido
+3.⛔ Retorna 500 se der error ao tentar listar as enquetes

--- a/requirements/surveys.md
+++ b/requirements/surveys.md
@@ -4,10 +4,11 @@
 
 1.⛔ Recebe uma requisição do tipo **GET** na rota **/api/surveys**
 2.⛔ Valida se a requisição foi feita por um usuário
-3.⛔ Retorna 200 com os dados das enquetes
+3.✅ Retorna 200 com os dados das enquetes
+4.⛔ Retorna 204 se não tiver nenhuma enquetes
 
 > ## Exceções
 
-1.⛔ Retorna erro 404 se a API não existir
+1.✅ Retorna erro 404 se a API não existir
 2.⛔ Retorna error 403 se não for um usuário válido
-3.⛔ Retorna 500 se der error ao tentar listar as enquetes
+3.✅ Retorna 500 se der error ao tentar listar as enquetes

--- a/src/data/protocols/db/survey/load-surveys-repository.ts
+++ b/src/data/protocols/db/survey/load-surveys-repository.ts
@@ -1,0 +1,5 @@
+import { SurveyModel } from '../../../../domain/models/survey'
+
+export interface LoadSurveysRepository {
+  loadAll: () => Promise<SurveyModel[]>
+}

--- a/src/data/usecases/add-survey/db-add-survey.spec.ts
+++ b/src/data/usecases/add-survey/db-add-survey.spec.ts
@@ -29,7 +29,8 @@ const makeFakeSurveyData = (): AddSurveyModel => ({
   answers: [{
     image: 'any_image',
     answer: 'any_answer'
-  }]
+  }],
+  date: new Date()
 })
 
 describe('DbAddSurvey UseCase', () => {

--- a/src/data/usecases/add-survey/db-add-survey.spec.ts
+++ b/src/data/usecases/add-survey/db-add-survey.spec.ts
@@ -1,3 +1,4 @@
+import MockDate from 'mockdate'
 import { AddSurveyModel, AddSurveyRepository } from './db-add-survey-protocols'
 import { DbAddSurvey } from './db-add-survey'
 
@@ -34,6 +35,13 @@ const makeFakeSurveyData = (): AddSurveyModel => ({
 })
 
 describe('DbAddSurvey UseCase', () => {
+  beforeAll(() => {
+    MockDate.set(new Date())
+  })
+
+  afterAll(() => {
+    MockDate.reset()
+  })
   test('Should call AddSurveyRepository with correct values', async () => {
     const { sut, addSurveyRepositoryStub } = makeSut()
     const addSpy = jest.spyOn(addSurveyRepositoryStub, 'add')

--- a/src/data/usecases/load-surveys/db-load-surveys.spec.ts
+++ b/src/data/usecases/load-surveys/db-load-surveys.spec.ts
@@ -1,11 +1,12 @@
 import { LoadSurveysRepository } from '../../protocols/db/survey/load-surveys-repository'
 import { SurveyModel } from '../../../domain/models/survey'
 import { DbLoadSurveys } from './db-load-surveys'
+import MockDate from 'mockdate'
 
 const makeLoadSurveysRepository = (): LoadSurveysRepository => {
   class LoadSurveysRepositoryStub implements LoadSurveysRepository {
     async loadAll (): Promise<SurveyModel[]> {
-      return await Promise.resolve(makeFakeSurveys())
+      return new Promise(resolve => resolve(makeFakeSurveys()))
     }
   }
   return new LoadSurveysRepositoryStub()
@@ -38,6 +39,14 @@ const makeFakeSurveys = (): SurveyModel[] => ([
 ])
 
 describe('DbLoadSurveys UseCase', () => {
+  beforeAll(() => {
+    MockDate.set(new Date())
+  })
+
+  afterAll(() => {
+    MockDate.reset()
+  })
+
   test('Should call LoadSurveysRepository', async () => {
     const { sut, loadSurveysRepositoryStub } = makeSut()
     const loadAllSpy = jest.spyOn(loadSurveysRepositoryStub, 'loadAll')
@@ -50,5 +59,11 @@ describe('DbLoadSurveys UseCase', () => {
     jest.spyOn(loadSurveysRepositoryStub, 'loadAll').mockRejectedValueOnce(new Error())
     const promise = sut.load()
     await expect(promise).rejects.toThrow()
+  })
+
+  test('Should return a list with surveys on success', async () => {
+    const { sut } = makeSut()
+    const surveys = await sut.load()
+    expect(surveys).toEqual(makeFakeSurveys())
   })
 })

--- a/src/data/usecases/load-surveys/db-load-surveys.spec.ts
+++ b/src/data/usecases/load-surveys/db-load-surveys.spec.ts
@@ -1,0 +1,47 @@
+import { LoadSurveysRepository } from '../../protocols/db/survey/load-surveys-repository'
+import { SurveyModel } from '../../../domain/models/survey'
+import { DbLoadSurveys } from './db-load-surveys'
+
+const makeLoadSurveysRepository = (): LoadSurveysRepository => {
+  class LoadSurveysRepositoryStub implements LoadSurveysRepository {
+    async loadAll (): Promise<SurveyModel[]> {
+      return await Promise.resolve(makeFakeSurveys())
+    }
+  }
+  return new LoadSurveysRepositoryStub()
+}
+
+interface SutTypes {
+  sut: DbLoadSurveys
+  loadSurveysRepositoryStub: LoadSurveysRepository
+}
+
+const makeSut = (): SutTypes => {
+  const loadSurveysRepositoryStub = makeLoadSurveysRepository()
+  const sut = new DbLoadSurveys(loadSurveysRepositoryStub)
+  return {
+    sut,
+    loadSurveysRepositoryStub
+  }
+}
+
+const makeFakeSurveys = (): SurveyModel[] => ([
+  {
+    id: 'any_id',
+    question: 'any_question',
+    answers: [{
+      image: 'any_image',
+      answer: 'any_answer'
+    }],
+    date: new Date()
+  }
+])
+
+describe('DbLoadSurveys UseCase', () => {
+  test('Should call LoadSurveysRepository', async () => {
+    const { sut, loadSurveysRepositoryStub } = makeSut()
+    const loadAllSpy = jest.spyOn(loadSurveysRepositoryStub, 'loadAll')
+    await sut.load()
+    expect(loadAllSpy).toHaveBeenCalled()
+  })
+})

--- a/src/data/usecases/load-surveys/db-load-surveys.spec.ts
+++ b/src/data/usecases/load-surveys/db-load-surveys.spec.ts
@@ -44,4 +44,11 @@ describe('DbLoadSurveys UseCase', () => {
     await sut.load()
     expect(loadAllSpy).toHaveBeenCalled()
   })
+
+  test('Should throws if LoadSurveysRepository throws', async () => {
+    const { sut, loadSurveysRepositoryStub } = makeSut()
+    jest.spyOn(loadSurveysRepositoryStub, 'loadAll').mockRejectedValueOnce(new Error())
+    const promise = sut.load()
+    await expect(promise).rejects.toThrow()
+  })
 })

--- a/src/data/usecases/load-surveys/db-load-surveys.ts
+++ b/src/data/usecases/load-surveys/db-load-surveys.ts
@@ -1,0 +1,11 @@
+import { SurveyModel } from '../../../domain/models/survey'
+import { LoadSurveys } from '../../../domain/usecases/load-surveys'
+import { LoadSurveysRepository } from '../../protocols/db/survey/load-surveys-repository'
+
+export class DbLoadSurveys implements LoadSurveys {
+  constructor (private readonly loadSurveysRepository: LoadSurveysRepository) {}
+  async load (): Promise<SurveyModel[]> {
+    await this.loadSurveysRepository.loadAll()
+    return new Promise(resolve => resolve([]))
+  }
+}

--- a/src/data/usecases/load-surveys/db-load-surveys.ts
+++ b/src/data/usecases/load-surveys/db-load-surveys.ts
@@ -5,7 +5,7 @@ import { LoadSurveysRepository } from '../../protocols/db/survey/load-surveys-re
 export class DbLoadSurveys implements LoadSurveys {
   constructor (private readonly loadSurveysRepository: LoadSurveysRepository) {}
   async load (): Promise<SurveyModel[]> {
-    await this.loadSurveysRepository.loadAll()
-    return new Promise(resolve => resolve([]))
+    const surveys = await this.loadSurveysRepository.loadAll()
+    return surveys
   }
 }

--- a/src/domain/models/survey.ts
+++ b/src/domain/models/survey.ts
@@ -1,0 +1,11 @@
+export interface SurveyModel {
+  id: string
+  question: string
+  answers: SurveyAnswerModel[]
+  date: Date
+}
+
+export interface SurveyAnswerModel {
+  image?: string
+  answer: string
+}

--- a/src/domain/usecases/add-survey.ts
+++ b/src/domain/usecases/add-survey.ts
@@ -1,6 +1,7 @@
 export interface AddSurveyModel {
   question: string
   answers: SurveyAnswer[]
+  date: Date
 }
 
 export interface SurveyAnswer {

--- a/src/domain/usecases/load-surveys.ts
+++ b/src/domain/usecases/load-surveys.ts
@@ -1,11 +1,12 @@
 import { SurveyAnswerModel } from '../models/survey'
 
-export interface AddSurveyModel {
+export interface SurveyModel {
+  id: string
   question: string
   answers: SurveyAnswerModel[]
   date: Date
 }
 
-export interface AddSurvey {
-  add: (data: AddSurveyModel) => Promise<void>
+export interface LoadSurveys {
+  load: () => Promise<SurveyModel[]>
 }

--- a/src/domain/usecases/load-surveys.ts
+++ b/src/domain/usecases/load-surveys.ts
@@ -1,11 +1,4 @@
-import { SurveyAnswerModel } from '../models/survey'
-
-export interface SurveyModel {
-  id: string
-  question: string
-  answers: SurveyAnswerModel[]
-  date: Date
-}
+import { SurveyModel } from '../models/survey'
 
 export interface LoadSurveys {
   load: () => Promise<SurveyModel[]>

--- a/src/infra/db/mongodb/survey/survey-mongo-repository.spec.ts
+++ b/src/infra/db/mongodb/survey/survey-mongo-repository.spec.ts
@@ -32,7 +32,8 @@ describe('Survey Mongo Repository', () => {
       },
       {
         answer: 'other_answer'
-      }]
+      }],
+      date: new Date()
     }
     await sut.add(surveyData)
     const survey = await surveyCollection.findOne({ question: surveyData.question })

--- a/src/presentation/controllers/survey/add-survey/add-survey-controller.spec.ts
+++ b/src/presentation/controllers/survey/add-survey/add-survey-controller.spec.ts
@@ -43,7 +43,8 @@ const makeFakeRequest = (): HttpRequest => ({
     answers: [{
       image: 'any_image',
       answer: 'any_answer'
-    }]
+    }],
+    date: new Date()
   }
 })
 

--- a/src/presentation/controllers/survey/add-survey/add-survey-controller.ts
+++ b/src/presentation/controllers/survey/add-survey/add-survey-controller.ts
@@ -8,7 +8,7 @@ export class AddSurveyController implements Controller {
       const error = this.validation.validate(httpRequest.body)
       if (error) return badRequest(error)
       const { question, answers } = httpRequest.body
-      await this.addSurvey.add({ question, answers })
+      await this.addSurvey.add({ question, answers, date: new Date() })
       return noContent()
     } catch (err) {
       return serverError(err)

--- a/src/presentation/controllers/survey/load-surveys/load-surveys-controller-protocols.ts
+++ b/src/presentation/controllers/survey/load-surveys/load-surveys-controller-protocols.ts
@@ -1,3 +1,4 @@
 /* istanbul ignore file */
 export * from '../../../protocols'
 export * from '../../../../domain/usecases/load-surveys'
+export * from '../../../../domain/models/survey'

--- a/src/presentation/controllers/survey/load-surveys/load-surveys-controller-protocols.ts
+++ b/src/presentation/controllers/survey/load-surveys/load-surveys-controller-protocols.ts
@@ -1,0 +1,3 @@
+/* istanbul ignore file */
+export * from '../../../protocols'
+export * from '../../../../domain/usecases/load-surveys'

--- a/src/presentation/controllers/survey/load-surveys/load-surveys-controller.spec.ts
+++ b/src/presentation/controllers/survey/load-surveys/load-surveys-controller.spec.ts
@@ -1,4 +1,4 @@
-import { ok, serverError } from '../../../helpers/http/http-helper'
+import { noContent, ok, serverError } from '../../../helpers/http/http-helper'
 import { LoadSurveysController } from './load-surveys-controller'
 import { LoadSurveys, SurveyModel, HttpRequest } from './load-surveys-controller-protocols'
 
@@ -58,11 +58,11 @@ describe('LoadSurveys Controller', () => {
     expect(httpResponse).toEqual(serverError(new Error()))
   })
 
-  test('Should return 200 with null on body if LoadSurveys returns null', async () => {
+  test('Should return 204 if LoadSurveys returns empty', async () => {
     const { sut, loadSurveysStub } = makeSut()
-    jest.spyOn(loadSurveysStub, 'load').mockResolvedValueOnce(new Promise(resolve => resolve(null as any)))
+    jest.spyOn(loadSurveysStub, 'load').mockResolvedValueOnce(new Promise(resolve => resolve([])))
     const httpResponse = await sut.handle(makeFakeRequest())
-    expect(httpResponse).toEqual(ok(null))
+    expect(httpResponse).toEqual(noContent())
   })
 
   test('Should return 200 on success', async () => {

--- a/src/presentation/controllers/survey/load-surveys/load-surveys-controller.spec.ts
+++ b/src/presentation/controllers/survey/load-surveys/load-surveys-controller.spec.ts
@@ -1,0 +1,61 @@
+import { serverError } from '../../../helpers/http/http-helper'
+import { LoadSurveysController } from './load-surveys-controller'
+import { HttpRequest } from '../../../protocols/https'
+import { LoadSurveys, SurveyModel } from './load-surveys-controller-protocols'
+
+const makeLoadSurveys = (): LoadSurveys => {
+  class LoadSurveysStub implements LoadSurveys {
+    async load (): Promise<SurveyModel[]> {
+      return new Promise(resolve => resolve(makeFakeSurveys()))
+    }
+  }
+  return new LoadSurveysStub()
+}
+
+interface SutTypes {
+  sut: LoadSurveysController
+  loadSurveysStub: LoadSurveys
+}
+
+const makeSut = (): SutTypes => {
+  const loadSurveysStub = makeLoadSurveys()
+  const sut = new LoadSurveysController(loadSurveysStub)
+  return {
+    sut,
+    loadSurveysStub
+  }
+}
+
+const makeFakeRequest = (): HttpRequest => ({
+  headers: {
+    'x-access-token': 'any_token'
+  }
+})
+
+const makeFakeSurveys = (): SurveyModel[] => ([
+  {
+    id: 'any_id',
+    question: 'any_question',
+    answers: [{
+      image: 'any_image',
+      answer: 'any_answer'
+    }],
+    date: new Date()
+  }
+])
+
+describe('LoadSurveys Controller', () => {
+  test('Should call LoadSurveys', async () => {
+    const { sut, loadSurveysStub } = makeSut()
+    const loadSpy = jest.spyOn(loadSurveysStub, 'load')
+    await sut.handle(makeFakeRequest())
+    expect(loadSpy).toHaveBeenCalled()
+  })
+
+  test('Should return 500 if LoadSurveys throws', async () => {
+    const { sut, loadSurveysStub } = makeSut()
+    jest.spyOn(loadSurveysStub, 'load').mockRejectedValueOnce(new Error())
+    const httpResponse = await sut.handle(makeFakeRequest())
+    expect(httpResponse).toEqual(serverError(new Error()))
+  })
+})

--- a/src/presentation/controllers/survey/load-surveys/load-surveys-controller.spec.ts
+++ b/src/presentation/controllers/survey/load-surveys/load-surveys-controller.spec.ts
@@ -1,3 +1,4 @@
+import MockDate from 'mockdate'
 import { noContent, ok, serverError } from '../../../helpers/http/http-helper'
 import { LoadSurveysController } from './load-surveys-controller'
 import { LoadSurveys, SurveyModel, HttpRequest } from './load-surveys-controller-protocols'
@@ -44,6 +45,13 @@ const makeFakeSurveys = (): SurveyModel[] => ([
 ])
 
 describe('LoadSurveys Controller', () => {
+  beforeAll(() => {
+    MockDate.set(new Date())
+  })
+
+  afterAll(() => {
+    MockDate.reset()
+  })
   test('Should call LoadSurveys', async () => {
     const { sut, loadSurveysStub } = makeSut()
     const loadSpy = jest.spyOn(loadSurveysStub, 'load')

--- a/src/presentation/controllers/survey/load-surveys/load-surveys-controller.spec.ts
+++ b/src/presentation/controllers/survey/load-surveys/load-surveys-controller.spec.ts
@@ -65,7 +65,7 @@ describe('LoadSurveys Controller', () => {
     expect(httpResponse).toEqual(ok(null))
   })
 
-  test('Should return 200 with surveys if LoadSurveys returns an surveys', async () => {
+  test('Should return 200 on success', async () => {
     const { sut } = makeSut()
     const httpResponse = await sut.handle(makeFakeRequest())
     expect(httpResponse).toEqual(ok(makeFakeSurveys()))

--- a/src/presentation/controllers/survey/load-surveys/load-surveys-controller.spec.ts
+++ b/src/presentation/controllers/survey/load-surveys/load-surveys-controller.spec.ts
@@ -1,7 +1,6 @@
-import { serverError } from '../../../helpers/http/http-helper'
+import { ok, serverError } from '../../../helpers/http/http-helper'
 import { LoadSurveysController } from './load-surveys-controller'
-import { HttpRequest } from '../../../protocols/https'
-import { LoadSurveys, SurveyModel } from './load-surveys-controller-protocols'
+import { LoadSurveys, SurveyModel, HttpRequest } from './load-surveys-controller-protocols'
 
 const makeLoadSurveys = (): LoadSurveys => {
   class LoadSurveysStub implements LoadSurveys {
@@ -57,5 +56,18 @@ describe('LoadSurveys Controller', () => {
     jest.spyOn(loadSurveysStub, 'load').mockRejectedValueOnce(new Error())
     const httpResponse = await sut.handle(makeFakeRequest())
     expect(httpResponse).toEqual(serverError(new Error()))
+  })
+
+  test('Should return 200 with null on body if LoadSurveys returns null', async () => {
+    const { sut, loadSurveysStub } = makeSut()
+    jest.spyOn(loadSurveysStub, 'load').mockResolvedValueOnce(new Promise(resolve => resolve(null as any)))
+    const httpResponse = await sut.handle(makeFakeRequest())
+    expect(httpResponse).toEqual(ok(null))
+  })
+
+  test('Should return 200 with surveys if LoadSurveys returns an surveys', async () => {
+    const { sut } = makeSut()
+    const httpResponse = await sut.handle(makeFakeRequest())
+    expect(httpResponse).toEqual(ok(makeFakeSurveys()))
   })
 })

--- a/src/presentation/controllers/survey/load-surveys/load-surveys-controller.ts
+++ b/src/presentation/controllers/survey/load-surveys/load-surveys-controller.ts
@@ -1,4 +1,4 @@
-import { ok, serverError } from '../../../helpers/http/http-helper'
+import { noContent, ok, serverError } from '../../../helpers/http/http-helper'
 import { Controller, HttpRequest, HttpResponse, LoadSurveys } from './load-surveys-controller-protocols'
 
 export class LoadSurveysController implements Controller {
@@ -6,6 +6,7 @@ export class LoadSurveysController implements Controller {
   async handle (httpRequest: HttpRequest): Promise<HttpResponse> {
     try {
       const surveys = await this.loadSurveys.load()
+      if (!surveys.length) return noContent()
       return ok(surveys)
     } catch (err) {
       return serverError(err)

--- a/src/presentation/controllers/survey/load-surveys/load-surveys-controller.ts
+++ b/src/presentation/controllers/survey/load-surveys/load-surveys-controller.ts
@@ -1,0 +1,14 @@
+import { serverError } from '../../../helpers/http/http-helper'
+import { Controller, HttpRequest, HttpResponse, LoadSurveys } from './load-surveys-controller-protocols'
+
+export class LoadSurveysController implements Controller {
+  constructor (private readonly loadSurveys: LoadSurveys) {}
+  async handle (httpRequest: HttpRequest): Promise<HttpResponse> {
+    try {
+      await this.loadSurveys.load()
+      return null
+    } catch (err) {
+      return serverError(err)
+    }
+  }
+}

--- a/src/presentation/controllers/survey/load-surveys/load-surveys-controller.ts
+++ b/src/presentation/controllers/survey/load-surveys/load-surveys-controller.ts
@@ -1,12 +1,12 @@
-import { serverError } from '../../../helpers/http/http-helper'
+import { ok, serverError } from '../../../helpers/http/http-helper'
 import { Controller, HttpRequest, HttpResponse, LoadSurveys } from './load-surveys-controller-protocols'
 
 export class LoadSurveysController implements Controller {
   constructor (private readonly loadSurveys: LoadSurveys) {}
   async handle (httpRequest: HttpRequest): Promise<HttpResponse> {
     try {
-      await this.loadSurveys.load()
-      return null
+      const surveys = await this.loadSurveys.load()
+      return ok(surveys)
     } catch (err) {
       return serverError(err)
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4594,6 +4594,11 @@ mkdirp@^1.0.3:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+mockdate@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.5.tgz#789be686deb3149e7df2b663d2bc4392bc3284fb"
+  integrity sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==
+
 mongodb-connection-string-url@^2.5.3, mongodb-connection-string-url@^2.5.4:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz#57901bf352372abdde812c81be47b75c6b2ec5cf"


### PR DESCRIPTION
- feat: ensure AddSurveyController call Validation with correct date
- docs: add surveys requirements
- feat: ensure LoadSurveysController calls LoadSurveys and returns 500 if LoadSurveys throws
- feat: ensure LoadSurveysController returns 200 if LoadSurveys returns an surveys
- feat: ensure LoadSurveyControler returns 200 on success
- docs: update requirements
- feat: ensure LoadSurveysController returns 204 if LoadSurveys returns empty
- feat: ensure DbLoadSurveys calls LoadSurveysRepository
- feat: ensure DbLoadSurveys throws if LoadSurveysRepository throws
- feat: add mockdate
