### PR TITLE
refator to use type alias insted of interfaces

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
     "@typescript-eslint/strict-boolean-expressions": "off",
     "@typescript-eslint/return-await": "off",
     "@typescript-eslint/no-misused-promises": "off",
-    "@typescript-eslint/no-floating-promises": "off"
+    "@typescript-eslint/no-floating-promises": "off",
+    "@typescript-eslint/consistent-type-definitions": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clean-node-types",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "index.js",
   "author": "Rafael Cavalcante <rafael.cavalcante@tallos.com.br>",
   "license": "MIT",

--- a/src/data/usecases/add-account/db-add-account.spec.ts
+++ b/src/data/usecases/add-account/db-add-account.spec.ts
@@ -47,7 +47,7 @@ const makeFakeAccount = (): AccountModel => ({
   password: 'hashed_password'
 })
 
-interface SutTypes {
+type SutTypes = {
   sut: DbAddAccount
   hasherStub: Hasher
   addAccountRepositoryStub: AddAccountRepository

--- a/src/data/usecases/add-survey/db-add-survey.spec.ts
+++ b/src/data/usecases/add-survey/db-add-survey.spec.ts
@@ -11,7 +11,7 @@ const makeAddSurveyRepository = (): AddSurveyRepository => {
   return new AddSurveyRepositoryStub()
 }
 
-interface SutTypes {
+type SutTypes = {
   sut: DbAddSurvey
   addSurveyRepositoryStub: AddSurveyRepository
 }

--- a/src/data/usecases/authentication/db-authentication.spec.ts
+++ b/src/data/usecases/authentication/db-authentication.spec.ts
@@ -45,7 +45,7 @@ const makeUpdateAccessTokenRepository = (): UpdateAccessTokenRepository => {
   return new UpdateAccessTokenRepositoryStub()
 }
 
-interface SutTypes {
+type SutTypes = {
   sut: DbAuthentication
   loadAccountByEmailRepositoryStub: LoadAccountByEmailRepository
   hashComparerStub: HashComparer

--- a/src/data/usecases/load-account-by-token/db-load-account-by-token.spec.ts
+++ b/src/data/usecases/load-account-by-token/db-load-account-by-token.spec.ts
@@ -21,7 +21,7 @@ const makeLoadAccountByTokenRepository = (): LoadAccountByTokenRepository => {
   return new LoadAccountByTokenRepositoryStub()
 }
 
-interface SutTypes {
+type SutTypes = {
   sut: DbLoadAccountByToken
   decrypterStub: Decrypter
   loadAccountByTokenRepositoryStub: LoadAccountByTokenRepository

--- a/src/data/usecases/load-surveys/db-load-surveys.spec.ts
+++ b/src/data/usecases/load-surveys/db-load-surveys.spec.ts
@@ -12,7 +12,7 @@ const makeLoadSurveysRepository = (): LoadSurveysRepository => {
   return new LoadSurveysRepositoryStub()
 }
 
-interface SutTypes {
+type SutTypes = {
   sut: DbLoadSurveys
   loadSurveysRepositoryStub: LoadSurveysRepository
 }

--- a/src/domain/models/account.ts
+++ b/src/domain/models/account.ts
@@ -1,4 +1,4 @@
-export interface AccountModel {
+export type AccountModel = {
   id: string
   name: string
   email: string

--- a/src/domain/models/authentication.ts
+++ b/src/domain/models/authentication.ts
@@ -1,4 +1,4 @@
-export interface AuthenticationModel {
+export type AuthenticationModel = {
   email: string
   password: string
 }

--- a/src/domain/models/survey.ts
+++ b/src/domain/models/survey.ts
@@ -1,11 +1,11 @@
-export interface SurveyModel {
+export type SurveyModel = {
   id: string
   question: string
   answers: SurveyAnswerModel[]
   date: Date
 }
 
-export interface SurveyAnswerModel {
+export type SurveyAnswerModel = {
   image?: string
   answer: string
 }

--- a/src/domain/usecases/add-account.ts
+++ b/src/domain/usecases/add-account.ts
@@ -1,6 +1,6 @@
 import { AccountModel } from '@/domain/models/account'
 
-export interface AddAccountModel {
+export type AddAccountModel = {
   name: string
   email: string
   password: string

--- a/src/main/decorators/log-controller-decorator.spec.ts
+++ b/src/main/decorators/log-controller-decorator.spec.ts
@@ -27,7 +27,7 @@ const makeController = (): Controller => {
   return new ControllerStub()
 }
 
-interface SutTypes {
+type SutTypes = {
   sut: LogControllerDecorator
   controllerStub: Controller
   logErrorRepositoryStub: LogErrorRepository

--- a/src/presentation/controllers/login/login/login-controller.spec.ts
+++ b/src/presentation/controllers/login/login/login-controller.spec.ts
@@ -21,7 +21,7 @@ const makeValidation = (): Validation => {
   return new ValidationStub()
 }
 
-interface SutTypes {
+type SutTypes = {
   sut: LoginController
   authenticationStub: Authentication
   validationStub: Validation

--- a/src/presentation/controllers/login/signup/signup-controller.spec.ts
+++ b/src/presentation/controllers/login/signup/signup-controller.spec.ts
@@ -45,7 +45,7 @@ const makeFakeAccount = (): AccountModel => ({
   password: 'valid_password'
 })
 
-interface SutTypes {
+type SutTypes = {
   sut: SignUpController
   validationStub: Validation
   addAccountStub: AddAccount

--- a/src/presentation/controllers/survey/add-survey/add-survey-controller.spec.ts
+++ b/src/presentation/controllers/survey/add-survey/add-survey-controller.spec.ts
@@ -20,7 +20,7 @@ const makeAddSurvey = (): AddSurvey => {
   return new AddSurveyStub()
 }
 
-interface SutTypes {
+type SutTypes = {
   sut: AddSurveyController
   validationStub: Validation
   addSurveyStub: AddSurvey

--- a/src/presentation/controllers/survey/load-surveys/load-surveys-controller.spec.ts
+++ b/src/presentation/controllers/survey/load-surveys/load-surveys-controller.spec.ts
@@ -12,7 +12,7 @@ const makeLoadSurveys = (): LoadSurveys => {
   return new LoadSurveysStub()
 }
 
-interface SutTypes {
+type SutTypes = {
   sut: LoadSurveysController
   loadSurveysStub: LoadSurveys
 }

--- a/src/presentation/middlewares/auth-middleware.spec.ts
+++ b/src/presentation/middlewares/auth-middleware.spec.ts
@@ -12,7 +12,7 @@ const makeLoadAccountByTokenRepositoryStub = (): LoadAccountByToken => {
   return new LoadAccountByToken()
 }
 
-interface SutTypes {
+type SutTypes = {
   sut: AuthMiddleware
   loadAccountByTokenStub: LoadAccountByToken
 }

--- a/src/presentation/protocols/https.ts
+++ b/src/presentation/protocols/https.ts
@@ -1,9 +1,9 @@
-export interface HttpResponse {
+export type HttpResponse = {
   statusCode: number
   body: any
 }
 
-export interface HttpRequest {
+export type HttpRequest = {
   body?: any
   headers?: any
 }

--- a/src/validation/validators/email-validation.spec.ts
+++ b/src/validation/validators/email-validation.spec.ts
@@ -10,7 +10,7 @@ const makeEmailValidator = (): EmailValidator => {
   }
   return new EmailValidatorStub()
 }
-interface SutTypes {
+type SutTypes = {
   sut: EmailValidation
   emailValidatorStub: EmailValidator
 }

--- a/src/validation/validators/validation-composite.spec.ts
+++ b/src/validation/validators/validation-composite.spec.ts
@@ -11,7 +11,7 @@ const makeValidation = (): Validation => {
   return new ValidationStub()
 }
 
-interface SutTypes {
+type SutTypes = {
   sut: ValidationComposite
   validationStubs: Validation[]
 }


### PR DESCRIPTION
- refactor: change models to use type alias instead of interfaces
- chore: release 2.0.1
